### PR TITLE
Fix custom hostnames Issue #9

### DIFF
--- a/s3fs.module
+++ b/s3fs.module
@@ -855,7 +855,8 @@ function _s3fs_get_amazons3_client() {
     }
     if (!empty($config->get('s3fs_use_customhost')) && !empty
       ($config->get('s3fs_hostname'))) {
-      $client_config['base_url'] = $config->get('s3fs_hostname');
+      $client_config['use_path_style_endpoint'] = false;
+      $client_config['endpoint'] = $config->get('s3fs_hostname');
     }
     // Create the Aws\S3\S3Client object with the specified configuration.
     // S3 Service only supports 2006-03-01 API version currently. V3 requires


### PR DESCRIPTION
The configuration options for v3 of the AWS SDK have changed, so I've updated the config for the hostname so that other S3 clone providers can work, such as Digital Ocean spaces.

Fixes #9 